### PR TITLE
refactor to suport SQLAlchemy 2.0 migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,7 @@ jobs:
           pip install coverage wheel pytest
           pip install -e ".[postgresql]"
       - name: Run the tests
-        run: |
-          pytest
+        run: make test
       - name: Build a distribution
         run: |
           python setup.py sdist bdist_wheel

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN pip install --no-binary=:pyicu: pyicu
 COPY . /ftmstore
 WORKDIR /ftmstore
 
-RUN pip3 install --no-cache-dir followthemoney SQLAlchemy postgres pytest
+RUN pip3 install --no-cache-dir -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,6 @@ RUN apt-get -qq -y update \
 RUN apt-get -qq -y install pkg-config libicu-dev
 RUN pip install --no-binary=:pyicu: pyicu
 
-# Environment variables used for the SQLAlchemy 2.0 migration
-ENV SQLALCHEMY_WARN_20='1' \
-    PYTHONWARNINGS='always'
-
 COPY . /ftmstore
 WORKDIR /ftmstore
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN pip install --no-binary=:pyicu: pyicu
 COPY . /ftmstore
 WORKDIR /ftmstore
 
-RUN pip3 install --no-cache-dir followthemoney SQLAlchemy postgres pytest pyicu
+RUN pip3 install --no-cache-dir followthemoney SQLAlchemy postgres pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -qq -y update \
-    && apt-get -qq -y install python3-pip python3-dev python3-pil  
+    && apt-get -qq -y install python3-pip python3-dev python3-pil
+
+RUN apt-get -qq -y install pkg-config libicu-dev
+RUN pip install --no-binary=:pyicu: pyicu
 
 # Environment variables used for the SQLAlchemy 2.0 migration
 ENV SQLALCHEMY_WARN_20='1' \
@@ -10,4 +14,4 @@ ENV SQLALCHEMY_WARN_20='1' \
 COPY . /ftmstore
 WORKDIR /ftmstore
 
-RUN pip3 install --no-cache-dir followthemoney SQLAlchemy postgres pytest
+RUN pip3 install --no-cache-dir followthemoney SQLAlchemy postgres pytest pyicu

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:20.04
+
+RUN apt-get -qq -y update \
+    && apt-get -qq -y install python3-pip python3-dev python3-pil  
+
+# Environment variables used for the SQLAlchemy 2.0 migration
+ENV SQLALCHEMY_WARN_20='1' \
+    PYTHONWARNINGS='always'
+
+COPY . /ftmstore
+WORKDIR /ftmstore
+
+RUN pip3 install --no-cache-dir followthemoney SQLAlchemy postgres pytest

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 db:
 	docker-compose up -d --remove-orphans postgres
 
-test: db
+test:
 	docker-compose run --rm ftmstore pytest -s tests
 
 stop:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 build:
-	docker build -t followthemoney-store .
+	docker-compose build --no-rm --parallel
 
-test:
-	docker run --rm followthemoney-store pytest
+db:
+	docker-compose up -d --remove-orphans postgres
+
+test: db
+	docker-compose run --rm ftmstore pytest -s tests
+
+stop:
+	docker-compose down --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build:
+	docker build -t followthemoney-store .
+
+test:
+	docker run --rm followthemoney-store pytest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.2"
+
+services:
+  ftmstore:
+    build:
+      context: .
+    hostname: ftmstore
+    tmpfs:
+      - /tmp:mode=777
+      - /data:mode=777
+    environment:
+      SQLALCHEMY_WARN_20: 1
+      PYTHONWARNINGS: always
+    volumes:
+      - "./ftmstore:/ftmstore/ftmstore"
+      - "./tests:/ftmstore/tests"
+      - "./data:/ingestors/data"
+      - "./setup.py:/ftmstore/setup.py"
+
+  postgres:
+    image: postgres:10.0
+    ports:
+      - "127.0.0.1:15432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DATABASE: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,8 @@ services:
     tmpfs:
       - /tmp:mode=777
       - /data:mode=777
-    environment:
-      SQLALCHEMY_WARN_20: 1
-      PYTHONWARNINGS: always
+    depends_on:
+      - postgres
     volumes:
       - "./ftmstore:/ftmstore/ftmstore"
       - "./tests:/ftmstore/tests"

--- a/ftmstore/store.py
+++ b/ftmstore/store.py
@@ -1,6 +1,6 @@
 from normality import slugify
 from sqlalchemy import create_engine, MetaData
-from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy import inspect as sqlalchemy_inspect
 
 from ftmstore import settings
 from ftmstore.dataset import Dataset
@@ -22,14 +22,14 @@ class Store(object):
         # config.setdefault('pool_size', 1)
         self.engine = create_engine(database_uri, **config)
         self.is_postgres = self.engine.dialect.name == "postgresql"
-        self.meta = MetaData(self.engine)
+        self.meta = MetaData()
 
     def get(self, name, origin=NULL_ORIGIN):
         return Dataset(self, name, origin=origin)
 
     def all(self, origin=NULL_ORIGIN):
         prefix = slugify("%s " % self.prefix, sep="_") + "_"
-        inspect = Inspector.from_engine(self.engine)
+        inspect = sqlalchemy_inspect(self.engine)
         for table in inspect.get_table_names():
             if table.startswith(prefix):
                 name = table[len(prefix) :]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Dependencies maintained by OCCRP
-followthemoney>=1.31.1
+followthemoney==3.3.0
 
-SQLAlchemy>=2.0.0
-postgres
+SQLAlchemy==2.0.9
+postgres==4.0
 
 # Testing dependencies
-pytest
+pytest==7.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# Dependencies maintained by OCCRP
+followthemoney>=1.31.1
+
+SQLAlchemy>=2.0.0
+postgres
+
+# Testing dependencies
+pytest

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup, find_packages
 with open("README.md") as f:
     long_description = f.read()
 
-
 setup(
     name="followthemoney-store",
     version="3.0.3",
@@ -27,7 +26,7 @@ setup(
     packages=find_packages(exclude=["ez_setup", "tests"]),
     include_package_data=True,
     zip_safe=True,
-    install_requires=["followthemoney>=1.31.1", "SQLAlchemy>=1.3.1"],
+    install_requires=[],
     extras_require={"postgresql": ["psycopg2-binary>=2.7"]},
     tests_require=[],
     entry_points={"followthemoney.cli": ["store = ftmstore.cli:cli"]},

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,6 +1,6 @@
 from ftmstore import init, settings
 
-settings.DATABASE_URI = "postgresql://postgres@localhost:5432"
+settings.DATABASE_URI = "postgresql://postgres:postgres@postgres:5432/postgres"
 # settings.DATABASE_URI = "postgresql://aleph:aleph@localhost:15432/aleph"
 
 
@@ -40,5 +40,5 @@ def test_postgres():
     assert len(list(dataset.iterate(entity_id="key1"))) == 1
     assert len(list(dataset.fragments(entity_ids="key1"))) == 2
 
-    dataset.table.drop()
+    dataset.drop()
     dataset.store.close()


### PR DESCRIPTION
Refactoring work is required to make FTM-store work with the latest version of SQLAlchemy (2.0+). 

Changes made:

- [x] [“Implicit” and “Connectionless” execution, “bound metadata” removed](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#implicit-and-connectionless-execution-bound-metadata-removed) - remove `self.engine` as a parameter passed to the `MetaData()` object instantiation
- [x] remove `Inspector.from_engine`, use `sqlalchemy.inspect()` called with `self.engine` as a parameter to obtain the `inspect` object that the `Store` class in `ftmstore` was using
- [x] [select() no longer accepts varied constructor arguments, columns are passed positionally](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#select-no-longer-accepts-varied-constructor-arguments-columns-are-passed-positionally) - pass `sqlalchemy.sql.functions` directly to `select()`
- [x]  [Many Choices becomes One Choice](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#many-choices-becomes-one-choice) - call `execute()` on a connection, not on the `Engine` object