### PR TITLE
Make FTMstore cross-compatible with SQLAlchemy 1.4 and 2+

### DIFF
--- a/ftmstore/store.py
+++ b/ftmstore/store.py
@@ -20,7 +20,7 @@ class Store(object):
         self.prefix = prefix
         self.database_uri = database_uri
         # config.setdefault('pool_size', 1)
-        self.engine = create_engine(database_uri, **config)
+        self.engine = create_engine(database_uri, future=True, **config)
         self.is_postgres = self.engine.dialect.name == "postgresql"
         self.meta = MetaData()
 


### PR DESCRIPTION
- [x] run the SQLAlchemy tests with a Postgres connection
- [x] use the `future=True` flag in the `create_engine` method in order to use the SQLA 2+ API in SQLA 1.4 (as per [the docs](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-to-2-0-step-four-use-the-future-flag-on-engine))

Without passing the `future=True` flag in the `create_engine` method, the following exception occurs when running the tests with SQLAlchemy 1.4:
```
[...]
            with self.store.engine.connect() as conn:
                conn.execute(stmt)
>               conn.commit()
E               AttributeError: 'Connection' object has no attribute 'commit'

ftmstore/dataset.py:77: AttributeError
[...]
RemovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    conn.execute(stmt)

```
